### PR TITLE
Resolves Issue #5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN wget -qO- ftp://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/5.3.0-HCP/fre
 RUN /bin/bash -c 'touch /opt/freesurfer/.license'
 
 RUN apt-get install -y python3
+RUN apt-get install -y python3-pip
+RUN pip3 install nibabel
 
 RUN apt-get install -y tcsh
 RUN apt-get install -y bc

--- a/README.md
+++ b/README.md
@@ -37,7 +37,13 @@ This App has the following command line arguments:
 		  {participant,group}   Level of the analysis that will be performed. Multiple
 		                        participant level analyses can be run independently
 		                        (in parallel) using the same output_dir.
-
+		required arguments:
+		  --license_key LICENSE_KEY
+		                        FreeSurfer license key - letters and numbers after "*"
+		                        in the email you received after registration. To
+		                        register (for free) visit
+		                        https://surfer.nmr.mgh.harvard.edu/registration.html
+		
 		optional arguments:
 		  -h, --help            show this help message and exit
 		  --participant_label PARTICIPANT_LABEL [PARTICIPANT_LABEL ...]
@@ -47,15 +53,19 @@ This App has the following command line arguments:
 		                        parameter is not provided all subjects should be
 		                        analyzed. Multiple participants can be specified with
 		                        a space separated list.
-		  --n_cpus N_CPUS       Number of CPUs/cores available to use.
+		  --n_cpus N_CPUS       Number of CPUs/cores available to use. (Default is 1)
+		  --stages {all,autorecon1,autorecon2,autorecon2-cp,autorecon2-wm,autorecon2-pial,autorecon3,autorecon-all}
+		                        Recon-all stages to run. (Default is autorecon-all)
 		  --template_name TEMPLATE_NAME
 		                        Name for the custom group level template generated
-		                        for this dataset
-		  --license_key LICENSE_KEY
-		                        FreeSurfer license key - letters and numbers after "*"
-		                        in the email you received after registration. To
-		                        register (for free) visit
-		                        https://surfer.nmr.mgh.harvard.edu/registration.html
+		                        for this dataset.
+		  --acquisition_label ACQUISITION_LABEL
+                    			If the dataset contains multiple T1 weighted images
+		                        from different acquisitions which one should be used?
+		                        Corresponds to "acq-<acquisition_label>"
+		  --refine_pial {T2,FLAIR}
+		  			If the dataset contains 3D T2 or T2 FLAIR weighted images
+					(~1x1x1), these can be used to refine the pial surface.
 
 To run it in participant level mode (for one participant):
 

--- a/run.py
+++ b/run.py
@@ -138,7 +138,7 @@ if args.analysis_level == "participant":
                             input_args += " " + " ".join(["-T2 %s"%T2])
                             input_args += " -T2pial"
                 elif args.refine_pial == "FLAIR":
-                        for FLAIR in FLAIRs:
+                    for FLAIR in FLAIRs:
                         if max(nibabel.load(FLAIR).header.get_zooms()) < 1.2:
                             input_args += " " + " ".join(["-FLAIR %s"%FLAIR])
                             input_args += " -FLAIRpial"

--- a/run.py
+++ b/run.py
@@ -53,8 +53,10 @@ parser.add_argument('--template_name', help='Name for the custom group level tem
 parser.add_argument('--license_key', help='FreeSurfer license key - letters and numbers after "*" in the email you received after registration. To register (for free) visit https://surfer.nmr.mgh.harvard.edu/registration.html',
                     required=True)
 parser.add_argument('--acquisition_label', help='If the dataset contains multiple T1 weighted images from different acquisitions which one should be used? Corresponds to "acq-<acquisition_label>"')
-parser.add_argument('--refine_pial', help='If the dataset contains 3D T2 or T2 FLAIR weighted images (~1x1x1), these can be used to refine the pial surface.',
-                    choices=['T2', 'FLAIR'],
+parser.add_argument('--refine_pial', help='If the dataset contains 3D T2 or T2 FLAIR weighted images (~1x1x1), '
+                    'these can be used to refine the pial surface. If you want to ignore these, specify None or '
+                    ' T1only to base surfaces on the T1 alone.',
+                    choices=['T2', 'FLAIR','None','T1only'],
                     default=['T2'])
 parser.add_argument('-v', '--version', action='version',
                     version='BIDS-App example version {}'.format(__version__))

--- a/run.py
+++ b/run.py
@@ -52,6 +52,8 @@ parser.add_argument('--template_name', help='Name for the custom group level tem
 parser.add_argument('--license_key', help='FreeSurfer license key - letters and numbers after "*" in the email you received after registration. To register (for free) visit https://surfer.nmr.mgh.harvard.edu/registration.html',
                     required=True)
 parser.add_argument('--acquisition_label', help='If the dataset contains multiple T1 weighted images from different acquisitions which one should be used? Corresponds to "acq-<acquisition_label>"')
+parser.add_argument('--T2pial', help='If the dataset contains 3D T2 weighted images (~1x1x1), these can be used to refine the pial surface.')
+parser.add_argument('--FLAIRpial', help='If the dataset contains 3D T2-FLAIR weighted images (~1x1x1), these can be used to refine the pial surface.')
 parser.add_argument('-v', '--version', action='version',
                     version='BIDS-App example version {}'.format(__version__))
 
@@ -125,9 +127,16 @@ if args.analysis_level == "participant":
                 T2s = glob(os.path.join(args.bids_dir, "sub-%s"%subject_label,
                                         "ses-%s"%session_label, "anat",
                                         "*_T2w.nii*"))
-                if T2s:
+                FLAIRs = glob(os.path.join(args.bids_dir, "sub-%s"%subject_label,
+                                        "ses-%s"%session_label, "anat",
+                                        "*_FLAIR.nii*"))
+                if T2pial:
                     input_args += " " + " ".join(["-T2 %s"%f for f in T2s])
                     input_args += " -T2pial"
+                elif FLAIRpial:
+                    input_args += " " + " ".join(["-FLAIR %s"%f for f in FLAIRs])
+                    input_args += " -FLAIRpial"
+
 
                 fsid = "sub-%s_ses-%s"%(subject_label, session_label)
                 timepoints.append(fsid)
@@ -177,9 +186,14 @@ if args.analysis_level == "participant":
                                                             "%s_T1w.nii*"%acq_tpl))])
             T2s = glob(os.path.join(args.bids_dir, "sub-%s"%subject_label, "anat",
                                     "*_T2w.nii*"))
-            if T2s:
+            FLAIRs = glob(os.path.join(args.bids_dir, "sub-%s"%subject_label, "anat",
+                                    "*_FLAIR.nii*"))
+            if T2pial:
                 input_args += " " + " ".join(["-T2 %s"%f for f in T2s])
                 input_args += " -T2pial"
+            if FLAIRpial:
+                input_args += " " + " ".join(["-FLAIR %s"%f for f in FLAIRs])
+                input_args += " -FLAIRpial"
             fsid = "sub-%s"%subject_label
             stages = " ".join(["-" + stage for stage in args.stages])
             cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d"%(fsid,

--- a/run.py
+++ b/run.py
@@ -55,7 +55,7 @@ parser.add_argument('--license_key', help='FreeSurfer license key - letters and 
 parser.add_argument('--acquisition_label', help='If the dataset contains multiple T1 weighted images from different acquisitions which one should be used? Corresponds to "acq-<acquisition_label>"')
 parser.add_argument('--refine_pial', help='If the dataset contains 3D T2 or T2 FLAIR weighted images (~1x1x1), these can be used to refine the pial surface.',
                     choices=['T2', 'FLAIR'],
-                   dafault=['T2'])
+                    default=['T2'])
 parser.add_argument('-v', '--version', action='version',
                     version='BIDS-App example version {}'.format(__version__))
 

--- a/run.py
+++ b/run.py
@@ -52,8 +52,8 @@ parser.add_argument('--template_name', help='Name for the custom group level tem
 parser.add_argument('--license_key', help='FreeSurfer license key - letters and numbers after "*" in the email you received after registration. To register (for free) visit https://surfer.nmr.mgh.harvard.edu/registration.html',
                     required=True)
 parser.add_argument('--acquisition_label', help='If the dataset contains multiple T1 weighted images from different acquisitions which one should be used? Corresponds to "acq-<acquisition_label>"')
-parser.add_argument('--T2pial', help='If the dataset contains 3D T2 weighted images (~1x1x1), these can be used to refine the pial surface.')
-parser.add_argument('--FLAIRpial', help='If the dataset contains 3D T2-FLAIR weighted images (~1x1x1), these can be used to refine the pial surface.')
+parser.add_argument('--refine_pial', help='If the dataset contains 3D T2 or T2 FLAIR weighted images (~1x1x1), these can be used to refine the pial surface.',
+                    choices=['T2', 'FLAIR'])
 parser.add_argument('-v', '--version', action='version',
                     version='BIDS-App example version {}'.format(__version__))
 
@@ -130,10 +130,10 @@ if args.analysis_level == "participant":
                 FLAIRs = glob(os.path.join(args.bids_dir, "sub-%s"%subject_label,
                                         "ses-%s"%session_label, "anat",
                                         "*_FLAIR.nii*"))
-                if T2pial:
+                if args.refine_pial == "T2":
                     input_args += " " + " ".join(["-T2 %s"%f for f in T2s])
                     input_args += " -T2pial"
-                elif FLAIRpial:
+                elif args.refine_pial == "FLAIR":
                     input_args += " " + " ".join(["-FLAIR %s"%f for f in FLAIRs])
                     input_args += " -FLAIRpial"
 
@@ -188,10 +188,10 @@ if args.analysis_level == "participant":
                                     "*_T2w.nii*"))
             FLAIRs = glob(os.path.join(args.bids_dir, "sub-%s"%subject_label, "anat",
                                     "*_FLAIR.nii*"))
-            if T2pial:
+            if args.refine_pial == "T2":
                 input_args += " " + " ".join(["-T2 %s"%f for f in T2s])
                 input_args += " -T2pial"
-            if FLAIRpial:
+            elif args.refine_pial == "FLAIR":
                 input_args += " " + " ".join(["-FLAIR %s"%f for f in FLAIRs])
                 input_args += " -FLAIRpial"
             fsid = "sub-%s"%subject_label


### PR DESCRIPTION
Added options for using T2 OR FLAIR images for pial refinement. The default is now to not use either, instead of automatically trying to use the T2s. (If this is not desired, then a resolution check for appropriateness should be added).