### PR TITLE
fixes behav in singl-session-subjects in long study

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
   override:
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
     - if [[ ! -d ~/data/ds114_test1 ]]; then wget -c -O ${HOME}/ds114_test1.tar "https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/57e54a326c613b01d7d3ed90" && mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test1.tar -C ${HOME}/data; fi
+    - if [[ ! -d ~/data/ds114_test2 ]]; then wget -c -O ${HOME}/ds114_test2.tar "https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/57e549f9b83f6901d457d162" && mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test2.tar -C ${HOME}/data; fi
     - git describe --tags > version
     - docker build -t bids/${CIRCLE_PROJECT_REPONAME} . :
         timeout: 21600
@@ -19,7 +20,9 @@ test:
   override:
     # print version
     - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} --version
-    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset -v ${HOME}/outputs1:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1:
+    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset -v ${HOME}/outputs1:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && ${HOME}/outputs1/sub-01/scripts/recon-all.done :
+        timeout: 21600
+    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test2:/bids_dataset -v ${HOME}/outputs2:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && ${HOME}/outputs2/sub-01_ses-retest.long.sub-01/scripts/recon-all.done && cat ${HOME}/outputs2/sub-01_ses-test.long.sub-01/scripts/recon-all.done :
         timeout: 21600
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,6 @@ dependencies:
   override:
     - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
     - if [[ ! -d ~/data/ds114_test1 ]]; then wget -c -O ${HOME}/ds114_test1.tar "https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/57e54a326c613b01d7d3ed90" && mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test1.tar -C ${HOME}/data; fi
-    - if [[ ! -d ~/data/ds114_test2 ]]; then wget -c -O ${HOME}/ds114_test2.tar "https://files.osf.io/v1/resources/9q7dv/providers/osfstorage/57e549f9b83f6901d457d162" && mkdir -p ${HOME}/data && tar xf ${HOME}/ds114_test2.tar -C ${HOME}/data; fi
     - git describe --tags > version
     - docker build -t bids/${CIRCLE_PROJECT_REPONAME} . :
         timeout: 21600
@@ -21,8 +20,6 @@ test:
     # print version
     - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} --version
     - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset -v ${HOME}/outputs1:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && cat ${HOME}/outputs1/sub-01/scripts/recon-all.done :
-        timeout: 21600
-    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test2:/bids_dataset -v ${HOME}/outputs2:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && cat ${HOME}/outputs2/sub-01_ses-retest.long.sub-01/scripts/recon-all.done && cat ${HOME}/outputs2/sub-01_ses-test.long.sub-01/scripts/recon-all.done :
         timeout: 21600
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -20,9 +20,9 @@ test:
   override:
     # print version
     - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset bids/${CIRCLE_PROJECT_REPONAME,,} --version
-    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset -v ${HOME}/outputs1:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && ${HOME}/outputs1/sub-01/scripts/recon-all.done :
+    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test1:/bids_dataset -v ${HOME}/outputs1:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && cat ${HOME}/outputs1/sub-01/scripts/recon-all.done :
         timeout: 21600
-    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test2:/bids_dataset -v ${HOME}/outputs2:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && ${HOME}/outputs2/sub-01_ses-retest.long.sub-01/scripts/recon-all.done && cat ${HOME}/outputs2/sub-01_ses-test.long.sub-01/scripts/recon-all.done :
+    - docker run -ti --rm --read-only -v /tmp:/tmp -v /var/tmp:/var/tmp -v ${HOME}/data/ds114_test2:/bids_dataset -v ${HOME}/outputs2:/outputs bids/${CIRCLE_PROJECT_REPONAME,,} /bids_dataset /outputs participant --participant_label 01 --license_key="~/test.key" --stages autorecon1 && cat ${HOME}/outputs2/sub-01_ses-retest.long.sub-01/scripts/recon-all.done && cat ${HOME}/outputs2/sub-01_ses-test.long.sub-01/scripts/recon-all.done :
         timeout: 21600
 
 deployment:

--- a/run.py
+++ b/run.py
@@ -104,8 +104,8 @@ if args.analysis_level == "participant":
         run("cp -rf " + os.path.join(os.environ["SUBJECTS_DIR"], "rh.EC_average") + " " + os.path.join(output_dir, "rh.EC_average"),
             ignore_errors=True)
 
+    # check if study is truly longitudinal
     for subject_label in subjects_to_analyze:
-
         # Check for multiple sessions to combine as a multiday session or as a longitudinal stream
         session_dirs = glob(os.path.join(args.bids_dir,"sub-%s"%subject_label,"ses-*"))
         sessions = [os.path.split(dr)[-1].split("-")[-1] for dr in session_dirs]
@@ -117,9 +117,10 @@ if args.analysis_level == "participant":
                                                 "anat",
                                                 "%s_T1w.nii*"%acq_tpl)):
                 n_valid_sessions += 1
-        if n_valid_sessions > 1 and args.multiple_sessions == "longitudinal":
-            longitudinal_study = True
+    if n_valid_sessions > 1 and args.multiple_sessions == "longitudinal":
+        longitudinal_study = True
 
+    for subject_label in subjects_to_analyze:
         timepoints = []
 
         if len(sessions) > 0 and longitudinal_study == True:

--- a/run.py
+++ b/run.py
@@ -123,6 +123,8 @@ if args.analysis_level == "participant":
     for subject_label in subjects_to_analyze:
         timepoints = []
 
+        session_dirs = glob(os.path.join(args.bids_dir,"sub-%s"%subject_label,"ses-*"))
+        sessions = [os.path.split(dr)[-1].split("-")[-1] for dr in session_dirs]
         if len(sessions) > 0 and longitudinal_study == True:
             # Running each session separately, prior to doing longitudinal pipeline
             for session_label in sessions:


### PR DESCRIPTION
In longitudinal studies (studies in which at least one subject has more than one session) and  `--multiple_sessions='longitudinal')` subjects with only one session should undergo the entire longitudinal stream. The changes in #11 broke that behavior.
The present changes should fix it.
