### PR TITLE
-3T flag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This App has the following command line arguments:
                       [--measurements {area,volume,thickness,thicknessstd,meancurv,gauscurv,foldind,curvind}
                                       [{area,volume,thickness,thicknessstd,meancurv,gauscurv,foldind,curvind} ...]]
                       [-v] [--bids_validator_config BIDS_VALIDATOR_CONFIG]
-                      [--skip_bids_validator]
+                      [--skip_bids_validator] [--3T {true,false}]
                       bids_dir output_dir {participant,group1,group2}
 
         FreeSurfer recon-all + custom template generation.
@@ -127,6 +127,9 @@ This App has the following command line arguments:
                                 info
           --skip_bids_validator
                                 skips bids validation
+	  --3T {true,false}     enables the two 3T specific options that recon-all
+	  			supports: nu intensity correction params, and the 
+				special schwartz atlas
 
 #### Participant level
 To run it in participant level mode (for one participant):

--- a/run.py
+++ b/run.py
@@ -208,6 +208,10 @@ if args.analysis_level == "participant":
                                                 "anat",
                                                 "%s_T1w.nii*" % acq_tpl))
                         input_args = ""
+                        
+                        if three_T == 'true':
+                            input_args += " -3T"
+
                         for T1 in T1s:
                             if (round(max(nibabel.load(T1).header.get_zooms()), 1) < 1.0 and args.hires_mode == "auto") or args.hires_mode == "enable":
                                 input_args += " -hires"
@@ -233,27 +237,13 @@ if args.analysis_level == "participant":
                         fsid = "sub-%s_ses-%s" % (subject_label, session_label)
                         stages = " ".join(["-" + stage for stage in args.stages])
 
-                        cmd=""
-                        resume_cmd = ""
-
-                        if three_T == 'true':
-                            cmd = "recon-all -subjid %s -sd %s -3T %s %s -openmp %d" % (fsid,
+                        
+                        cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
                                                                                           output_dir,
                                                                                           input_args,
                                                                                           stages,
                                                                                           args.n_cpus)
-                            resume_cmd = "recon-all -subjid %s -sd %s -3T %s -openmp %d" % (fsid,
-                                                                                              output_dir,
-                                                                                              stages,
-                                                                                              args.n_cpus)
-
-                        else:
-                            cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
-                                                                                          output_dir,
-                                                                                          input_args,
-                                                                                          stages,
-                                                                                          args.n_cpus)
-                            resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
+                        resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
                                                                                               output_dir,
                                                                                               stages,
                                                                                               args.n_cpus)
@@ -279,14 +269,7 @@ if args.analysis_level == "participant":
                     fsid = "sub-%s" % subject_label
                     stages = " ".join(["-" + stage for stage in args.stages])
 
-                    if three_T == 'true':
-                        cmd = "recon-all -base %s -sd %s -3T %s %s -openmp %d" % (fsid,
-                                                                                    output_dir,
-                                                                                    input_args,
-                                                                                    stages,
-                                                                                    args.n_cpus)
-                    else:
-                        cmd = "recon-all -base %s -sd %s %s %s -openmp %d" % (fsid,
+                    cmd = "recon-all -base %s -sd %s %s %s -openmp %d" % (fsid,
                                                                                     output_dir,
                                                                                     input_args,
                                                                                     stages,
@@ -313,14 +296,7 @@ if args.analysis_level == "participant":
                         fsid = "sub-%s" % subject_label
                         stages = " ".join(["-" + stage for stage in args.stages])
                         
-                        if three_T == 'true':
-                            cmd = "recon-all -long %s %s -sd %s -3T %s -openmp %d" % (tp,
-                                                                                        fsid,
-                                                                                        output_dir,
-                                                                                        stages,
-                                                                                        args.n_cpus)
-                        else:
-                            cmd = "recon-all -long %s %s -sd %s %s -openmp %d" % (tp,
+                        cmd = "recon-all -long %s %s -sd %s %s -openmp %d" % (tp,
                                                                                         fsid,
                                                                                         output_dir,
                                                                                         stages,
@@ -345,6 +321,10 @@ if args.analysis_level == "participant":
                                         "anat",
                                         "%s_T1w.nii*" % acq_tpl))
                 input_args = ""
+
+                if three_T == 'true':
+                            input_args += " -3T"
+
                 for T1 in T1s:
                     if (round(max(nibabel.load(T1).header.get_zooms()), 1) < 1.0 and args.hires_mode == "auto") or args.hires_mode == "enable":
                         input_args += " -hires"
@@ -374,23 +354,12 @@ if args.analysis_level == "participant":
                 fsid = "sub-%s" % subject_label
                 stages = " ".join(["-" + stage for stage in args.stages])
 
-                if three_T == 'true':
-                    cmd = "recon-all -subjid %s -sd %s -3T %s %s -openmp %d" % (fsid,
+                cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
                                                                                   output_dir,
                                                                                   input_args,
                                                                                   stages,
                                                                                   args.n_cpus)
-                    resume_cmd = "recon-all -subjid %s -sd %s -3T %s -openmp %d" % (fsid,
-                                                                                      output_dir,
-                                                                                      stages,
-                                                                                      args.n_cpus)    
-                else:
-                    cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
-                                                                                  output_dir,
-                                                                                  input_args,
-                                                                                  stages,
-                                                                                  args.n_cpus)
-                    resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
+                resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
                                                                                       output_dir,
                                                                                       stages,
                                                                                       args.n_cpus)
@@ -421,7 +390,12 @@ if args.analysis_level == "participant":
             if not T1s:
                 print("No T1w nii files found for subject %s. Skipping subject." % subject_label)
                 continue
+
             input_args = ""
+            
+            if three_T == 'true':
+                            input_args += " -3T"
+
             for T1 in T1s:
                 if (round(max(nibabel.load(T1).header.get_zooms()), 1) < 1.0 and args.hires_mode == "auto") or args.hires_mode == "enable":
                     input_args += " -hires"
@@ -444,23 +418,12 @@ if args.analysis_level == "participant":
             fsid = "sub-%s" % subject_label
             stages = " ".join(["-" + stage for stage in args.stages])
             
-            if three_T == 'true':
-                cmd = "recon-all -subjid %s -sd %s -3T %s %s -openmp %d" % (fsid,
+            cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
                                                                               output_dir,
                                                                               input_args,
                                                                               stages,
                                                                               args.n_cpus)
-                resume_cmd = "recon-all -subjid %s -sd %s -3T %s -openmp %d" % (fsid,
-                                                                                  output_dir,
-                                                                                  stages,
-                                                                                  args.n_cpus)
-            else:
-                cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
-                                                                              output_dir,
-                                                                              input_args,
-                                                                              stages,
-                                                                              args.n_cpus)
-                resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
+            resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
                                                                                   output_dir,
                                                                                   stages,
                                                                                   args.n_cpus)

--- a/run.py
+++ b/run.py
@@ -232,12 +232,28 @@ if args.analysis_level == "participant":
 
                         fsid = "sub-%s_ses-%s" % (subject_label, session_label)
                         stages = " ".join(["-" + stage for stage in args.stages])
-                        cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
+
+                        cmd=""
+                        resume_cmd = ""
+
+                        if three_T == 'true':
+                            cmd = "recon-all -subjid %s -sd %s -3T %s %s -openmp %d" % (fsid,
                                                                                           output_dir,
                                                                                           input_args,
                                                                                           stages,
                                                                                           args.n_cpus)
-                        resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
+                            resume_cmd = "recon-all -subjid %s -sd %s -3T %s -openmp %d" % (fsid,
+                                                                                              output_dir,
+                                                                                              stages,
+                                                                                              args.n_cpus)
+
+                        else:
+                            cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
+                                                                                          output_dir,
+                                                                                          input_args,
+                                                                                          stages,
+                                                                                          args.n_cpus)
+                            resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
                                                                                               output_dir,
                                                                                               stages,
                                                                                               args.n_cpus)
@@ -262,7 +278,15 @@ if args.analysis_level == "participant":
                     input_args = " ".join(["-tp %s" % tp for tp in timepoints])
                     fsid = "sub-%s" % subject_label
                     stages = " ".join(["-" + stage for stage in args.stages])
-                    cmd = "recon-all -base %s -sd %s %s %s -openmp %d" % (fsid,
+
+                    if three_T == 'true':
+                        cmd = "recon-all -base %s -sd %s -3T %s %s -openmp %d" % (fsid,
+                                                                                    output_dir,
+                                                                                    input_args,
+                                                                                    stages,
+                                                                                    args.n_cpus)
+                    else:
+                        cmd = "recon-all -base %s -sd %s %s %s -openmp %d" % (fsid,
                                                                                     output_dir,
                                                                                     input_args,
                                                                                     stages,
@@ -288,7 +312,15 @@ if args.analysis_level == "participant":
                         # longitudinally process all timepoints
                         fsid = "sub-%s" % subject_label
                         stages = " ".join(["-" + stage for stage in args.stages])
-                        cmd = "recon-all -long %s %s -sd %s %s -openmp %d" % (tp,
+                        
+                        if three_T == 'true':
+                            cmd = "recon-all -long %s %s -sd %s -3T %s -openmp %d" % (tp,
+                                                                                        fsid,
+                                                                                        output_dir,
+                                                                                        stages,
+                                                                                        args.n_cpus)
+                        else:
+                            cmd = "recon-all -long %s %s -sd %s %s -openmp %d" % (tp,
                                                                                         fsid,
                                                                                         output_dir,
                                                                                         stages,
@@ -341,12 +373,24 @@ if args.analysis_level == "participant":
 
                 fsid = "sub-%s" % subject_label
                 stages = " ".join(["-" + stage for stage in args.stages])
-                cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
+
+                if three_T == 'true':
+                    cmd = "recon-all -subjid %s -sd %s -3T %s %s -openmp %d" % (fsid,
                                                                                   output_dir,
                                                                                   input_args,
                                                                                   stages,
                                                                                   args.n_cpus)
-                resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
+                    resume_cmd = "recon-all -subjid %s -sd %s -3T %s -openmp %d" % (fsid,
+                                                                                      output_dir,
+                                                                                      stages,
+                                                                                      args.n_cpus)    
+                else:
+                    cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
+                                                                                  output_dir,
+                                                                                  input_args,
+                                                                                  stages,
+                                                                                  args.n_cpus)
+                    resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
                                                                                       output_dir,
                                                                                       stages,
                                                                                       args.n_cpus)
@@ -399,12 +443,24 @@ if args.analysis_level == "participant":
 
             fsid = "sub-%s" % subject_label
             stages = " ".join(["-" + stage for stage in args.stages])
-            cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
+            
+            if three_T == 'true':
+                cmd = "recon-all -subjid %s -sd %s -3T %s %s -openmp %d" % (fsid,
                                                                               output_dir,
                                                                               input_args,
                                                                               stages,
                                                                               args.n_cpus)
-            resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
+                resume_cmd = "recon-all -subjid %s -sd %s -3T %s -openmp %d" % (fsid,
+                                                                                  output_dir,
+                                                                                  stages,
+                                                                                  args.n_cpus)
+            else:
+                cmd = "recon-all -subjid %s -sd %s %s %s -openmp %d" % (fsid,
+                                                                              output_dir,
+                                                                              input_args,
+                                                                              stages,
+                                                                              args.n_cpus)
+                resume_cmd = "recon-all -subjid %s -sd %s %s -openmp %d" % (fsid,
                                                                                   output_dir,
                                                                                   stages,
                                                                                   args.n_cpus)

--- a/run.py
+++ b/run.py
@@ -102,7 +102,14 @@ parser.add_argument('--bids_validator_config', help='JSON file specifying config
 parser.add_argument('--skip_bids_validator',
                     help='skips bids validation',
                     action='store_true')
+parser.add_argument('--3T',
+                    help='enables the two 3T specific options that recon-all supports: nu intensity correction params, and the special schwartz atlas',
+                    choices = ['true', 'false'],
+                    default = 'true')
 args = parser.parse_args()
+
+
+three_T = vars(args)['3T']
 
 if args.bids_validator_config:
     run("bids-validator --config {config} {bids_dir}".format(
@@ -119,6 +126,7 @@ if args.acquisition_label:
     acq_tpl = "*acq-%s*" % args.acquisition_label
 else:
     acq_tpl = "*"
+
 
 # if there are session folders, check if study is truly longitudinal by
 # searching for the first subject with more than one valid sessions


### PR DESCRIPTION
recon-all for freesurfer has a -3T flag (https://surfer.nmr.mgh.harvard.edu/fswiki/OtherUsefulFlags) that you can pass to the command. It enables freesurfer to do intensity corrections that create more accurate segmentations for 3T scans. 

I've added the option to pass in [--3T {true, false}] to the docker image (default is true). If true, recon-all will run with the -3T flag added to the command. 