### PR TITLE
Creating symbolic links for the template directories is safer than checking if directories exist while running multiple instances in same directory.

### DIFF
--- a/run.py
+++ b/run.py
@@ -10,6 +10,7 @@ import subprocess
 from warnings import warn
 import pandas as pd
 import re
+import errno
 
 def run(command, env={}, ignore_errors=False):
     merged_env = os.environ
@@ -177,9 +178,14 @@ else:
 
 # running participant level
 if args.analysis_level == "participant":
-    if not os.path.exists(os.path.join(output_dir, "fsaverage")):
-        run("cp -rf " + os.path.join(os.environ["SUBJECTS_DIR"], "fsaverage") + " " + os.path.join(output_dir, "fsaverage"),
-            ignore_errors=True)
+    try:
+        os.symlink(os.path.join(os.environ["SUBJECTS_DIR"], "fsaverage"),os.path.join(output_dir, "fsaverage"))
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            print("fsaverage sympolic link already exists")
+        else:
+            print("fsaverage symbolic link unable to be created because, {0}".format(str(e)))
+            raise e
     if not os.path.exists(os.path.join(output_dir, "lh.EC_average")):
         run("cp -rf " + os.path.join(os.environ["SUBJECTS_DIR"], "lh.EC_average") + " " + os.path.join(output_dir, "lh.EC_average"),
             ignore_errors=True)

--- a/run.py
+++ b/run.py
@@ -178,20 +178,16 @@ else:
 
 # running participant level
 if args.analysis_level == "participant":
-    try:
-        os.symlink(os.path.join(os.environ["SUBJECTS_DIR"], "fsaverage"),os.path.join(output_dir, "fsaverage"))
-    except OSError as e:
-        if e.errno == errno.EEXIST:
-            print("fsaverage sympolic link already exists")
-        else:
-            print("fsaverage symbolic link unable to be created because, {0}".format(str(e)))
-            raise e
-    if not os.path.exists(os.path.join(output_dir, "lh.EC_average")):
-        run("cp -rf " + os.path.join(os.environ["SUBJECTS_DIR"], "lh.EC_average") + " " + os.path.join(output_dir, "lh.EC_average"),
-            ignore_errors=True)
-    if not os.path.exists(os.path.join(output_dir, "rh.EC_average")):
-        run("cp -rf " + os.path.join(os.environ["SUBJECTS_DIR"], "rh.EC_average") + " " + os.path.join(output_dir, "rh.EC_average"),
-            ignore_errors=True)
+    fst_links_to_make = ["fsaverage", "lh.EC_average","rh.EC_average"]
+    for fst in fst_links_to_make:
+        try:
+            os.symlink(os.path.join(os.environ["SUBJECTS_DIR"], fst),os.path.join(output_dir, fst))
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                print("Symbolic link to {0} already exists".format(fst))
+            else:
+                print("ERROR: Symbolic link to {0} unable to be created because: {1}".format(fst,str(e)))
+                raise e
 
     for subject_label in subjects_to_analyze:
         if glob(os.path.join(args.bids_dir, "sub-%s" % subject_label, "ses-*")):


### PR DESCRIPTION
Replaced the three copy commands that were using run to use os.symlink as creating the symlink is much safer on shared file systems when running multiple instances of the tool simultaneously.