### PR TITLE
Update deployment and add version notice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,15 +5,12 @@ jobs:
   build:
     machine:
       image: ubuntu-2204:2022.10.2
-    resource_class: xlarge
+    resource_class: large
     parameters:
       version:
         type: string
     steps:
     - checkout
-    - restore_cache:
-        keys:
-        - v_0-image_cache_fs<< parameters.version >>-{{ checksum "Dockerfile_fs<< parameters.version >>" }}
     - run:
         name: load and build
         command: |
@@ -29,11 +26,6 @@ jobs:
           echo "cHJpbnRmICJEeWxhbi5OaWVsc29uQGdtYWlsLmNvbVxuMzcwNjNcbiAqQ1lrZWhQYUNvRDlNXG4gRlM2N1BTWmRFV2lqb1xuIiA+IH4vbGljZW5zZS9saWNlbnNlLnR4dA==" | base64 -d | sh
           cp ~/license/license.txt ~/license_fs<< parameters.version >>/license.txt
           rm -r ~/license
-    - save_cache:
-        key: v_0-image_cache_fs<< parameters.version >>-{{ checksum "Dockerfile_fs<< parameters.version >>" }}-{{ .Revision }}-{{ epoch }}
-        paths:
-        - ~/docker
-        - ~/license_fs<< parameters.version >>
     - persist_to_workspace:
         root: /home/circleci
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
 
                   if [[  -n "${CIRCLE_TAG}" ]]; then
                       : "Pushing to DockerHub ${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
-                      if [[ FSVERSION -eq v6 ]]; then
+                      if [[ FSVERSION -eq v6 ]]; then 
                          docker push "${user_name}/${repo_name}:latest"
                       fi
 
@@ -249,6 +249,7 @@ workflows:
             only: /.*/
 
     - test:
+        name: test_<< matrix.version >>
         matrix:
           parameters:
             version: ['6', '7']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
 
                   if [[  -n "${CIRCLE_TAG}" ]]; then
                       : "Pushing to DockerHub ${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
-                      if [[ FSVERSION -eq v6 ]]; then 
+                      if [[ FSVERSION -eq v6 ]]; then
                          docker push "${user_name}/${repo_name}:latest"
                       fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,20 +198,25 @@ jobs:
 
               # make sure we have a lowercase repo
               user_name="bids"
-              repo_name=$(echo "${CIRCLE_PROJECT_REPONAME}_fs<< parameters.version >>" | tr '[:upper:]' '[:lower:]')
+              repo_name=$(echo "${CIRCLE_PROJECT_REPONAME}" | tr '[:upper:]' '[:lower:]')
+              FSVERSION=v<< parameters.version >>
 
               if [[ -n "${DOCKER_TOKEN}" ]]; then
                   echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_USER}" --password-stdin
 
                   : "Pushing to DockerHub ${user_name}/${repo_name}:unstable"
-                  docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:unstable"
-                  docker push "${user_name}/${repo_name}:unstable"
+                  docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSVERSION}-unstable"
+                  docker push "${user_name}/${repo_name}:${FSVERSION}-unstable"
 
-                  if [[ -n "${CIRCLE_TAG}" ]]; then
-                      : "Pushing to DockerHub ${user_name}/${repo_name}:${CIRCLE_TAG}"
-                      docker push "${user_name}/${repo_name}:latest"
-                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${CIRCLE_TAG}"
-                      docker push "${user_name}/${repo_name}:${CIRCLE_TAG}"
+                  if [[  -n "${CIRCLE_TAG}" ]]; then
+                      : "Pushing to DockerHub ${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
+                      if [[ FSVERSION -eq v6 ]]; then 
+                         docker push "${user_name}/${repo_name}:latest"
+                      fi
+
+                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSVERSION}"
+                      docker push ${user_name}/${repo_name}:${FSVERSION}
+                      docker push "${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
                   fi
 
               fi
@@ -263,7 +268,7 @@ workflows:
         context:
         - dockerhub
         requires:
-        - test
+        - test_<< matrix.version >>
         filters:
           branches:
             ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     machine:
       image: ubuntu-2204:2022.10.2
-    resource_class: x-large
+    resource_class: xlarge
     parameters:
       version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
   build:
     machine:
       image: ubuntu-2204:2022.10.2
+    resource_class: large
     parameters:
       version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     machine:
       image: ubuntu-2204:2022.10.2
-    resource_class: large
+    resource_class: x-large
     parameters:
       version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,30 +199,30 @@ jobs:
               # make sure we have a lowercase repo
               user_name="bids"
               repo_name=$(echo "${CIRCLE_PROJECT_REPONAME}" | tr '[:upper:]' '[:lower:]')
-              FSMAJORVERSION=<< parameters.version >>
-              if [[ FSMAJORVERSION -eq 6 ]]; then
-                FSVERSION=6.0.1
+              FS_MAJOR_VERSION=<< parameters.version >>
+              if [[ FS_MAJOR_VERSION -eq 6 ]]; then
+                FS_VERSION=6.0.1
               else
-                FSVERSION=7.4.1
+                FS_VERSION=7.4.1
               fi
 
               if [[ -n "${DOCKER_TOKEN}" ]]; then
                   echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_USER}" --password-stdin
 
                   : "Pushing to DockerHub ${user_name}/${repo_name}:unstable"
-                  docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSVERSION}-unstable"
-                  docker push "${user_name}/${repo_name}:${FSVERSION}-unstable"
+                  docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FS_VERSION}-unstable"
+                  docker push "${user_name}/${repo_name}:${FS_VERSION}-unstable"
 
                   if [[  -n "${CIRCLE_TAG}" ]]; then
-                      : "Pushing to DockerHub ${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
-                      if [[ FSMAJORVERSION -eq 6 ]]; then
+                      : "Pushing to DockerHub ${user_name}/${repo_name}:${FS_VERSION}-${CIRCLE_TAG}"
+                      if [[ FS_MAJOR_VERSION -eq 6 ]]; then
                          docker push "${user_name}/${repo_name}:latest"
                       fi
 
-                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSMAJORVERSION}"
-                      docker push ${user_name}/${repo_name}:${FSMAJORVERSION}
-                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
-                      docker push "${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
+                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FS_MAJOR_VERSION}"
+                      docker push ${user_name}/${repo_name}:${FS_MAJOR_VERSION}
+                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FS_VERSION}-${CIRCLE_TAG}"
+                      docker push "${user_name}/${repo_name}:${FS_VERSION}-${CIRCLE_TAG}"
                   fi
 
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,12 @@ jobs:
               # make sure we have a lowercase repo
               user_name="bids"
               repo_name=$(echo "${CIRCLE_PROJECT_REPONAME}" | tr '[:upper:]' '[:lower:]')
-              FSVERSION=v<< parameters.version >>
+              FSMAJORVERSION=<< parameters.version >>
+              if [[ FSMAJORVERSION -eq 6 ]]; then
+                FSVERSION=6.0.1
+              else
+                FSVERSION=7.4.1
+              fi
 
               if [[ -n "${DOCKER_TOKEN}" ]]; then
                   echo "${DOCKER_TOKEN}" | docker login -u "${DOCKER_USER}" --password-stdin
@@ -210,12 +215,13 @@ jobs:
 
                   if [[  -n "${CIRCLE_TAG}" ]]; then
                       : "Pushing to DockerHub ${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
-                      if [[ FSVERSION -eq v6 ]]; then
+                      if [[ FSMAJORVERSION -eq 6 ]]; then
                          docker push "${user_name}/${repo_name}:latest"
                       fi
 
-                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSVERSION}"
-                      docker push ${user_name}/${repo_name}:${FSVERSION}
+                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSMAJORVERSION}"
+                      docker push ${user_name}/${repo_name}:${FSMAJORVERSION}
+                      docker tag "${user_name}/${repo_name}" "${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
                       docker push "${user_name}/${repo_name}:${FSVERSION}-${CIRCLE_TAG}"
                   fi
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 ### Description
 This app implements surface reconstruction using Freesurfer. It reconstructs the surface for each subject individually and then
-creates a study specific template. In case there are multiple sessions the Freesurfer longitudinal pipeline is used (creating subject specific templates) unless instructed to combine data across sessions. This app is available for both Freesurfer 6 and 7.
+creates a study specific template. In case there are multiple sessions the Freesurfer longitudinal pipeline is used (creating subject specific templates) unless instructed to combine data across sessions. This app is available for both Freesurfer 6 and 7. 
 
-The current Freesurfer version for Freesurfer 6 is based on: freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.1.tar.gz
+The current Freesurfer version for Freesurfer 6 is based on: freesurfer-Linux-centos6_x86_64-stable-pub-v6.0.1.tar.gz  
 The current Freesurfer version for Freesurfer 7 is based on: freesurfer-linux-centos7_x86_64-7.4.1.tar.gz
 
+We only plan to support ove version of Freesurfer 6 and Freesurfer 7 at a time.
+
 The output of the pipeline consist of the SUBJECTS_DIR created during the analysis.
+
+### How to get it
+
+Freesurfer 6 will remain the default image till 2024, at which point Freesurfer 7 will become the default.
+
+You can get the default version with `docker pull bids/freesurfer`.  
+
+Freesurfer 7 is available at `docker pull bids/freesurfer:7`.  
+
+Freesurfer 6 is available at `docker pull bids/freesurfer:6`.  
 
 ### Documentation
  - [Surface reconstruction](https://surfer.nmr.mgh.harvard.edu/fswiki/recon-all)


### PR DESCRIPTION
Addresses #76. `docker pull bids/freesurfer`, `docker pull bids/freesurfer:v6`, and `docker pull bids/freesurfer:v6-${CIRCLETAG}` will pull FreeSurfer 6.     
`docker pull bids/freesurfer:v7`, and `docker pull bids/freesurfer:v7-${CIRCLETAG}` will pull FreeSurfer 7.

I've added a warning as well. If you're ok with this arrangment @Remi-Gau, I can also update the readme in this PR.